### PR TITLE
Fix bug on Order / Transaction relation

### DIFF
--- a/src/Traits/ShopTransactionTrait.php
+++ b/src/Traits/ShopTransactionTrait.php
@@ -24,7 +24,7 @@ trait ShopTransactionTrait
      */
     public function order()
     {
-        return $this->belongsTo(Config::get('shop.order_table'), 'order_id');
+        return $this->belongsTo(Config::get('shop.order'), 'order_id');
     }
 
     /**


### PR DESCRIPTION
We should get the class name, not table name. Fixes :
 [Symfony\Component\Debug\Exception\FatalErrorException]
  Class 'orders' not found
